### PR TITLE
Add HMAC benchmark

### DIFF
--- a/benchmark/example_benchmark_test.go
+++ b/benchmark/example_benchmark_test.go
@@ -1,13 +1,13 @@
-package main
+package benchmark
 
 import (
 	"github.com/google/go-tpm/tpm2"
 	"github.com/google/go-tpm/tpm2/transport"
-	"github.com/stiankri/tpm-benchmark/benchmark"
 	"log"
+	"log/slog"
 )
 
-func main() {
+func Example() {
 	tpm, err := transport.OpenTPM()
 	if err != nil {
 		log.Fatal(err)
@@ -15,10 +15,10 @@ func main() {
 	defer tpm.Close()
 
 	tpmAlgorithms := []tpm2.TPMAlgID{tpm2.TPMAlgECC, tpm2.TPMAlgRSA}
-	sessionEncryptions := []benchmark.SessionEncryption{benchmark.SessionEncryptionNone}
+	sessionEncryptions := []SessionEncryption{SessionEncryptionNone}
 
 	var (
-		sessionEncryption  benchmark.SessionEncryption
+		sessionEncryption  SessionEncryption
 		signatureAlgorithm tpm2.TPMAlgID
 	)
 
@@ -27,9 +27,12 @@ func main() {
 
 	for _, sessionEncryption = range sessionEncryptions {
 		for _, signatureAlgorithm = range tpmAlgorithms {
-			benchmark.Benchmark(tpm, signatureAlgorithm, iterations, parallelism, sessionEncryption)
+			err := Signature(tpm, signatureAlgorithm, iterations, parallelism, sessionEncryption)
+			if err != nil {
+				slog.Debug(err.Error())
+			}
 		}
 
-		benchmark.HmacBenchmark(tpm, iterations, parallelism, sessionEncryption)
+		Hmac(tpm, iterations, parallelism, sessionEncryption)
 	}
 }

--- a/cmd/tpm-benchmark/main.go
+++ b/cmd/tpm-benchmark/main.go
@@ -137,16 +137,22 @@ func main() {
 		var signatureAlgorithm tpm2.TPMAlgID
 		for _, sessionEncryption = range allSessionEncryptions {
 			for _, signatureAlgorithm = range allTpmAlgs {
-				benchmark.Benchmark(tpm, signatureAlgorithm, iterations, parallelism, sessionEncryption)
+				err := benchmark.Signature(tpm, signatureAlgorithm, iterations, parallelism, sessionEncryption)
+				if err != nil {
+					slog.Debug(err.Error())
+				}
 			}
 
-			benchmark.HmacBenchmark(tpm, iterations, parallelism, sessionEncryption)
+			benchmark.Hmac(tpm, iterations, parallelism, sessionEncryption)
 		}
 	} else {
 		if hmac {
-			benchmark.HmacBenchmark(tpm, iterations, parallelism, sessionEncryption)
+			benchmark.Hmac(tpm, iterations, parallelism, sessionEncryption)
 		} else {
-			benchmark.Benchmark(tpm, signatureAlgorithm, iterations, parallelism, sessionEncryption)
+			err := benchmark.Signature(tpm, signatureAlgorithm, iterations, parallelism, sessionEncryption)
+			if err != nil {
+				slog.Debug(err.Error())
+			}
 		}
 	}
 }

--- a/cmd/tpm-benchmark/main.go
+++ b/cmd/tpm-benchmark/main.go
@@ -15,11 +15,11 @@ const usage = `Usage:
     tpm-benchmark [OPTIONS]
 
 Options:
-    -a                      Run all signatures (ECC 256 and RSA 2048) and all
-                            session encryption (none, reuse, ephemeral).
+    --all                   Run all algorithms (ECC 256, RSA 2048 and HMAC) and
+                            all session encryption (none, reuse, ephemeral).
 
-    -s SIGNATURE_TYPE       Choose 'ecc' for 256 bit ECDSA or 'rsa' for 2048 
-                            bit RSASSA signature.
+    -a ALGORITHM            Choose 'ecc' for 256 bit ECDSA, 'rsa' for 2048 
+                            bit RSASSA signature or 'hmac' for SHA256 HMAC.
 
     -e SESSION_ENCRYPTION   Choose 'none', 'reuse' (same session for all
                             signature calls to the TPM) or 'ephemeral' session
@@ -35,7 +35,7 @@ Run default with ECC 256 and no session encryption
     $ tpm-benchmark
 
 Run all tests with parallelism 1
-    $ tpm-benchmark -a
+    $ tpm-benchmark --all
 
 Run RSA 2048 with session encryption reuse
     $ tpm-benchmark -s rsa -e reuse
@@ -55,13 +55,13 @@ func main() {
 	}
 
 	var (
-		allFlag, debugMode                             bool
-		signatureAlgorithm, sessionEncryptionAlgorithm string
-		parallelism, iterations                        int
+		allFlag, debugMode                    bool
+		algorithm, sessionEncryptionAlgorithm string
+		parallelism, iterations               int
 	)
 
-	flag.BoolVar(&allFlag, "a", false, "Run all signatures and all session encryption benchmark")
-	flag.StringVar(&signatureAlgorithm, "s", "", "Signing algorithm 'ecc' or 'rsa'")
+	flag.BoolVar(&allFlag, "all", false, "Run all signatures and all session encryption benchmark")
+	flag.StringVar(&algorithm, "a", "", "Algorithm 'ecc', 'rsa' or 'hmac'")
 	flag.StringVar(&sessionEncryptionAlgorithm, "e", "", "Session encryption 'none', 'reuse', 'ephemeral'")
 	flag.IntVar(&parallelism, "p", 1, "Parallelism 1,2,...,10")
 	flag.IntVar(&iterations, "i", 30, "Iterations 1,2,...,100")
@@ -80,22 +80,25 @@ func main() {
 
 	slog.SetDefault(logger)
 
-	if allFlag && (signatureAlgorithm != "" || sessionEncryptionAlgorithm != "") {
+	if allFlag && (algorithm != "" || sessionEncryptionAlgorithm != "") {
 		flag.Usage()
 		os.Exit(1)
 	}
 
-	signatureAlg := tpm2.TPMAlgECC
-	if signatureAlgorithm != "" {
-		if signatureAlgorithm != "rsa" && signatureAlgorithm != "ecc" {
+	signatureAlgorithm := tpm2.TPMAlgECC
+	hmac := false
+	if algorithm != "" {
+		if algorithm != "rsa" && algorithm != "ecc" && algorithm != "hmac" {
 			flag.Usage()
 			os.Exit(1)
 		} else {
-			switch signatureAlgorithm {
+			switch algorithm {
 			case "ecc":
-				signatureAlg = tpm2.TPMAlgECC
+				signatureAlgorithm = tpm2.TPMAlgECC
 			case "rsa":
-				signatureAlg = tpm2.TPMAlgRSA
+				signatureAlgorithm = tpm2.TPMAlgRSA
+			case "hmac":
+				hmac = true
 			}
 		}
 	}
@@ -136,8 +139,14 @@ func main() {
 			for _, signatureAlgorithm = range allTpmAlgs {
 				benchmark.Benchmark(tpm, signatureAlgorithm, iterations, parallelism, sessionEncryption)
 			}
+
+			benchmark.HmacBenchmark(tpm, iterations, parallelism, sessionEncryption)
 		}
 	} else {
-		benchmark.Benchmark(tpm, signatureAlg, iterations, parallelism, sessionEncryption)
+		if hmac {
+			benchmark.HmacBenchmark(tpm, iterations, parallelism, sessionEncryption)
+		} else {
+			benchmark.Benchmark(tpm, signatureAlgorithm, iterations, parallelism, sessionEncryption)
+		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -3,5 +3,6 @@ module github.com/stiankri/tpm-benchmark
 go 1.22.0
 
 require github.com/google/go-tpm v0.9.1-0.20240222210053-08987cedf981
+replace github.com/google/go-tpm => github.com/stiankri/go-tpm v0.0.0-20240317152650-6725f5804355
 
 require golang.org/x/sys v0.17.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/google/go-tpm v0.9.1-0.20240222210053-08987cedf981 h1:TbYxisx+/QhyK/Us9yFLpQ82nOnQxfVl1bqTTqgW894=
-github.com/google/go-tpm v0.9.1-0.20240222210053-08987cedf981/go.mod h1:FkNVkc6C+IsvDI9Jw1OveJmxGZUUaKxtrpOS47QWKfU=
+github.com/stiankri/go-tpm v0.0.0-20240317152650-6725f5804355 h1:XvMi2GpwbtUdDe841OajufaTAbJtSfP5fWYFVA2cx14=
+github.com/stiankri/go-tpm v0.0.0-20240317152650-6725f5804355/go.mod h1:FkNVkc6C+IsvDI9Jw1OveJmxGZUUaKxtrpOS47QWKfU=
 golang.org/x/sys v0.17.0 h1:25cE3gD+tdBA7lp7QfhuV+rJiE9YXTcS3VG1SqssI/Y=
 golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/usage/main.go
+++ b/usage/main.go
@@ -29,5 +29,7 @@ func main() {
 		for _, signatureAlgorithm = range tpmAlgorithms {
 			benchmark.Benchmark(tpm, signatureAlgorithm, iterations, parallelism, sessionEncryption)
 		}
+
+		benchmark.HmacBenchmark(tpm, iterations, parallelism, sessionEncryption)
 	}
 }


### PR DESCRIPTION
TPM2_HMAC is defined in https://trustedcomputinggroup.org/wp-content/uploads/TCG_TPM2_r1p59_Part3_Commands_pub.pdf.

The upstream `google/go-tpm` goes not support TPM2_HMAC, so using my own fork https://github.com/stiankri/go-tpm/commit/6725f580435547c54fdb6baf186c745021ae8ba5.

